### PR TITLE
Replace ``guacamole`` with ``hotdogb`` in OnePlus 7T download link

### DIFF
--- a/devices.html
+++ b/devices.html
@@ -353,7 +353,7 @@
         <span class="span-color">Matheus Vieira</span>
           <div class="links" >
 	    <a href="https://forum.xda-developers.com/t/rom-12-derpfest-shinju.4214727/"class="button glow-button">XDA Thread</a>
-            <a href="https://sourceforge.net/projects/derpfest/files/guacamole/" class="button glow-button btn-download">Download</a>
+            <a href="https://sourceforge.net/projects/derpfest/files/hotdogb/" class="button glow-button btn-download">Download</a>
             <a href="https://raw.githubusercontent.com/DerpFest-12/Updater-Stuff/master/changelog_guacamole.txt" class="button glow-button">Changelogs</a>
           </div>
           


### PR DESCRIPTION
``hotdogb`` is the correct code name for the OnePlus 7T. Previously, this link would lead to downloads for the OnePlus *7 Pro* (aka. ``guacamole``) instead!