### PR TITLE
Derpsite: Add 404.html and vercel.json to fix routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0;url=/" />
+    <script>window.location.replace("/" + location.search + location.hash)</script>
+    <title>Redirecting…</title>
+  </head>
+  <body>Redirecting…</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
No longer shows 404 on reloading pages other than homepage.
Test here https://derpfest-os.vercel.app/
You can open https://derpfest-os.vercel.app/build directly but not https://derpfest.org/build